### PR TITLE
清理 BeforeAfter 组件，移除过度的提示和描述文本

### DIFF
--- a/website/src/components/BeforeAfter.astro
+++ b/website/src/components/BeforeAfter.astro
@@ -29,16 +29,9 @@ if (!demo) throw new Error(`No demo for id "${id}"`);
         </span>
       </button>
     </div>
-    <span class="ba-hint">
-      <T zh="点按对照两种处理" en="Tap to compare the two treatments" ja="タップで2つの扱いを見比べる" ko="눌러서 두 가지 처리를 비교한다" />
-    </span>
   </div>
 
   <div class={`ba-stage demo-${id}`}>
-    {/* Tags live on the stage (not inside a pane) so the reveal transform
-        can't re-anchor them — they stay pinned to the stage's top-right. */}
-    <span class="ba-tag before" aria-hidden="true"><T zh="SLOP" en="SLOP" ja="SLOP" ko="SLOP" /></span>
-    <span class="ba-tag after" aria-hidden="true"><T zh="清理后" en="CLEAN" ja="CLEAN" ko="CLEAN" /></span>
 
     <div class="ba-pane" data-pane="before">
       <Fragment set:html={demo.before} />


### PR DESCRIPTION
这才是 AI slop！🤣
按钮的作用已经很明确了，不再需要提示文本描述。