### PR TITLE
Fix scanner reliability and site accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ so common you've stopped seeing it.
 **Kill AI Slop** is two things:
 
 1. **A website**, a multilingual field guide (English, Chinese, Japanese, and
-   Korean) that catalogues 32 AI-slop tells, each with an interactive
+   Korean) that catalogues 33 AI-slop tells, each with an interactive
    before→after demo showing the clean fix. The site is itself built as a
    rebuttal to everything it catalogues.
 2. **An Agent Skill**, `kill-ai-slop`, which turns that catalogue into action:

--- a/skill/scripts/scan.mjs
+++ b/skill/scripts/scan.mjs
@@ -12,13 +12,19 @@
 */
 
 import { readFileSync, readdirSync, statSync } from "node:fs";
-import { join, extname, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import { dirname, extname, join, relative, resolve } from "node:path";
 
 const args = process.argv.slice(2);
 const root = args.find((a) => !a.startsWith("-")) || ".";
 const asJson = args.includes("--json");
 const useColor =
   !args.includes("--no-color") && process.stdout.isTTY && !asJson;
+const resolvedRoot = resolve(root);
+const skillRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const escapeTerminal = (text) => text.replace(/[\0-\x1f\x7f-\x9f]/g, (char) =>
+  `\\x${char.codePointAt(0).toString(16).padStart(2, "0")}`,
+);
 
 const SKIP_DIRS = new Set([
   "node_modules", ".git", "dist", "build", "out", ".next", ".astro",
@@ -70,6 +76,8 @@ const TELLS = [
       /linear-gradient[^;)]*(?:to bottom|180deg|to top)/i,
       /bg-gradient-to-[bt]\b[\s\S]{0,40}?from-/i,
       /repeating-(?:linear|radial)-gradient/i,
+      /bg-gradient-to-(?:br|tr|bl|tl)\b[\s\S]{0,40}?from-(?:emerald|green|teal|cyan|purple|violet|fuchsia)-\d+\/(?:5|10|15|20|25)/i,
+      /box-shadow:[^;{}]*(?:#(?:6366f1|8b5cf6|a855f7|22d3ee|06b6d4)|rgba?\(\s*(?:139|168))/i,
     ] },
   { id: "07", group: "type", name: "serif-italic emphasis", fix: "emphasise by weight, one voice",
     patterns: [
@@ -92,6 +100,7 @@ const TELLS = [
     patterns: [
       /\buppercase\b[\s\S]{0,40}?tracking-(?:wide|wider|widest)\b|tracking-(?:wide|wider|widest)\b[\s\S]{0,40}?\buppercase\b/i,
       /\b(?:eyebrow|kicker|overline)\b/i,
+      /text-transform:\s*uppercase[\s\S]{0,80}?letter-spacing:\s*0?\.\d+em/i,
     ] },
   { id: "11", group: "type", name: "full-sentence display headline", fix: "few words big; specifics in a subline",
     patterns: [
@@ -113,7 +122,7 @@ const TELLS = [
   { id: "14", group: "copy", name: "AI copywriting voice", fix: "say the specific thing",
     copy: true,
     patterns: [
-      /not just .{1,40}\bit'?s\b/i,
+      /not just .{1,40}\bit(?:['’])?s\b/i,
       /\b(say goodbye to|meet your new|supercharge|unlock the power of|in seconds,? not)\b/i,
       /\b(blazing[- ]fast|effortless(?:ly)?|seamless(?:ly)?|game[- ]?changer|next[- ]level)\b/i,
       /\b(?:growth|security|process|privacy|productivity|compliance|feature|innovation) theater\b/i,
@@ -185,6 +194,7 @@ const TELLS = [
       /\btransition-all\b/,
       /cubic-bezier\([^)]*,\s*1\.[2-9]/,
       /\banimate-bounce\b/,
+      /transition:[^;{}]*\b(?:width|height|margin|padding)\b/i,
     ] },
   { id: "27", group: "layout", name: "all-caps card grid", fix: "show the one key thing fully",
     patterns: [
@@ -203,6 +213,7 @@ const TELLS = [
     patterns: [
       /['"`>]0[1-9]['"`<]/,
       /text-[789]xl[\s\S]{0,50}?(?:text-(?:gray|slate|zinc|neutral)-(?:100|200)|opacity-(?:5|10|20))/i,
+      /\bstep[- ](?:one|two|three)\b/i,
     ] },
   { id: "30", group: "layout", name: "cards inside cards", fix: "one surface per region; hairlines inside",
     patterns: [
@@ -215,7 +226,7 @@ const TELLS = [
   { id: "32", group: "evolved", name: "Inter everywhere", fix: "compare faces; be able to say why this one",
     patterns: [
       /fonts\.googleapis\.com\/css2\?family=(?:Inter|Space\+Grotesk|Manrope|Plus\+Jakarta)/i,
-      /font-family:\s*[^;]*(?:\bInter\b|Space Grotesk|Manrope|Plus Jakarta Sans)/,
+      /font-family:\s*[^;]*(?:\bInter\b|Space Grotesk|Manrope|Plus Jakarta Sans|\bGeist\b)/,
       /\b(?:Inter|Space_Grotesk|Manrope|Plus_Jakarta_Sans)\b[\s\S]{0,60}?next\/font\/google|next\/font\/google[\s\S]{0,60}?\b(?:Inter|Space_Grotesk|Manrope|Plus_Jakarta_Sans)\b/,
     ] },
   { id: "33", group: "evolved", name: "tasteful-terminal", fix: "mono for code only",
@@ -227,6 +238,7 @@ const TELLS = [
 ];
 
 function walk(dir, files = []) {
+  if (resolve(dir) === skillRoot) return files;
   let entries;
   try {
     entries = readdirSync(dir, { withFileTypes: true });
@@ -239,7 +251,7 @@ function walk(dir, files = []) {
     }
     const full = join(dir, e.name);
     if (e.isDirectory()) {
-      if (SKIP_DIRS.has(e.name)) continue;
+      if (SKIP_DIRS.has(e.name) || resolve(full) === skillRoot) continue;
       walk(full, files);
     } else if (e.isFile()) {
       const base = e.name;
@@ -261,16 +273,36 @@ function scanFile(path) {
   } catch {
     return [];
   }
-  const isCode = ![".md", ".mdx"].includes(extname(path));
+  const isCode = extname(path) !== ".md";
   const lines = text.split(/\r?\n/);
+  const lineStarts = [0];
+  for (let index = text.indexOf("\n"); index !== -1; index = text.indexOf("\n", index + 1)) {
+    lineStarts.push(index + 1);
+  }
   const hits = [];
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    if (line.length > 2000) continue; // minified-ish
-    for (const tell of TELLS) {
-      if (!tell.copy && !isCode) continue; // code-only tell in a prose file
-      if (tell.patterns.some((re) => re.test(line))) {
-        hits.push({ tell, line: i + 1, text: line.trim().slice(0, 100) });
+  const seen = new Set();
+  for (const tell of TELLS) {
+    if (!tell.copy && !isCode) continue; // code-only tell in a prose file
+    for (const pattern of tell.patterns) {
+      const matcher = new RegExp(pattern.source, `${pattern.flags}g`);
+      let match;
+      while ((match = matcher.exec(text))) {
+        let low = 0;
+        let high = lineStarts.length - 1;
+        while (low < high) {
+          const middle = Math.ceil((low + high) / 2);
+          if (lineStarts[middle] <= match.index) low = middle;
+          else high = middle - 1;
+        }
+        const lineIndex = low;
+        const line = lines[lineIndex];
+        if (line.length > 2000) continue; // minified-ish
+        const key = `${tell.id}:${lineIndex}`;
+        if (!seen.has(key)) {
+          seen.add(key);
+          hits.push({ tell, line: lineIndex + 1, text: line.trim().slice(0, 100) });
+        }
+        if (match[0] === "") matcher.lastIndex += 1;
       }
     }
   }
@@ -278,12 +310,21 @@ function scanFile(path) {
 }
 
 // ---- run ----
-const files = walk(root);
+try {
+  if (!statSync(resolvedRoot).isDirectory()) {
+    throw new Error("not a directory");
+  }
+} catch {
+  console.error(`Scan root must be an existing directory: ${escapeTerminal(root)}`);
+  process.exit(1);
+}
+
+const files = walk(resolvedRoot);
 const byTell = new Map(); // id -> { tell, hits: [{file,line,text}] }
 for (const f of files) {
   for (const h of scanFile(f)) {
     if (!byTell.has(h.tell.id)) byTell.set(h.tell.id, { tell: h.tell, hits: [] });
-    byTell.get(h.tell.id).hits.push({ file: relative(root, f) || f, line: h.line, text: h.text });
+    byTell.get(h.tell.id).hits.push({ file: relative(resolvedRoot, f) || f, line: h.line, text: h.text });
   }
 }
 
@@ -318,7 +359,7 @@ const red = (s) => c("31", s);
 const dim = (s) => c("2", s);
 const bold = (s) => c("1", s);
 
-console.log(`\n${bold("kill-ai-slop")} — scanned ${files.length} files under ${root}\n`);
+console.log(`\n${bold("kill-ai-slop")} — scanned ${files.length} files under ${escapeTerminal(root)}\n`);
 if (groups.length === 0) {
   console.log("No slop signals found. (Still trust your eyes — open the pages.)\n");
   process.exit(0);
@@ -328,7 +369,7 @@ for (const g of groups) {
   console.log(`${red("slop")} ${bold(g.tell.id)} ${g.tell.name}  ${dim("→ " + g.tell.fix)}`);
   const shown = g.hits.slice(0, 12);
   for (const h of shown) {
-    console.log(`     ${dim(h.file + ":" + h.line)}  ${h.text}`);
+    console.log(`     ${dim(escapeTerminal(h.file + ":" + h.line))}  ${escapeTerminal(h.text)}`);
   }
   if (g.hits.length > shown.length) {
     console.log(dim(`     … and ${g.hits.length - shown.length} more`));

--- a/skill/scripts/scan.test.mjs
+++ b/skill/scripts/scan.test.mjs
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import { copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const scriptPath = join(dirname(fileURLToPath(import.meta.url)), "scan.mjs");
+
+function withTempProject(run) {
+  const project = mkdtempSync(join(tmpdir(), "kill-ai-slop-"));
+  try {
+    return run(project);
+  } finally {
+    rmSync(project, { recursive: true, force: true });
+  }
+}
+
+function scan(root, ...args) {
+  return spawnSync(process.execPath, [scriptPath, root, ...args], {
+    encoding: "utf8",
+  });
+}
+
+function reportFor(root) {
+  const result = scan(root, "--json");
+  assert.equal(result.status, 0, result.stderr);
+  return JSON.parse(result.stdout);
+}
+
+function finding(report, id) {
+  return report.findings.find((entry) => entry.id === id);
+}
+
+test("rejects a missing scan root instead of reporting a clean scan", () => {
+  withTempProject((project) => {
+    const control = "\u001b]52;c;not-a-clipboard\u0007";
+    const result = scan(join(project, `missing-${control}`), "--json");
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /Scan root must be an existing directory/);
+    assert.equal(result.stderr.includes(control), false);
+    assert.ok(result.stderr.includes("\\x1b]52;c;not-a-clipboard\\x07"));
+    assert.equal(result.stdout, "");
+
+    const file = join(project, "source.css");
+    writeFileSync(file, "");
+    const fileResult = scan(file, "--json");
+    assert.notEqual(fileResult.status, 0);
+    assert.match(fileResult.stderr, /Scan root must be an existing directory/);
+  });
+});
+
+test("finds multiline patterns and documented runtime signals", () => {
+  withTempProject((project) => {
+    writeFileSync(
+      join(project, "signals.tsx"),
+      `<div className="from-indigo-500\n  to-violet-600" />\n<p>not just fast — it’s reliable</p>\n`,
+    );
+    writeFileSync(join(project, "Page.mdx"), `<div className="bg-clip-text text-transparent" />\n`);
+    writeFileSync(
+      join(project, "signals.css"),
+      `.wash { background: bg-gradient-to-br from-emerald-500/10; }\n` +
+        `.glow { box-shadow: 0 0 1rem #6366f1; }\n` +
+        `.kicker { text-transform: uppercase; letter-spacing: 0.1em; }\n` +
+        `.panel { transition: width 200ms ease; }\n` +
+        `.steps::before { content: "step one"; }\n` +
+        `.body { font-family: Geist, sans-serif; }\n`,
+    );
+
+    const report = reportFor(project);
+    assert.equal(finding(report, "01")?.hits[0].line, 1);
+    for (const id of ["02", "06", "10", "14", "26", "29", "32"]) {
+      assert.ok(finding(report, id), `expected tell ${id} to be detected`);
+    }
+  });
+});
+
+test("skips the installed skill's own files", () => {
+  withTempProject((project) => {
+    const installedScript = join(
+      project,
+      ".claude",
+      "skills",
+      "kill-ai-slop",
+      "scripts",
+      "scan.mjs",
+    );
+    mkdirSync(dirname(installedScript), { recursive: true });
+    copyFileSync(scriptPath, installedScript);
+
+    const result = spawnSync(process.execPath, [installedScript, project, "--json"], {
+      encoding: "utf8",
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(JSON.parse(result.stdout).filesScanned, 0);
+  });
+});
+
+test("escapes control characters in human output", () => {
+  withTempProject((project) => {
+    const control = "\u001b]52;c;not-a-clipboard\u0007";
+    writeFileSync(
+      join(project, "unsafe.css"),
+      `.x { background: linear-gradient(to bottom, red, blue); ${control} }`,
+    );
+
+    const result = scan(project, "--no-color");
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout.includes(control), false);
+    assert.ok(result.stdout.includes("\\x1b]52;c;not-a-clipboard\\x07"));
+
+    const jsonResult = scan(project, "--json");
+    assert.equal(jsonResult.status, 0, jsonResult.stderr);
+    assert.doesNotThrow(() => JSON.parse(jsonResult.stdout));
+  });
+});

--- a/website/src/components/BeforeAfter.astro
+++ b/website/src/components/BeforeAfter.astro
@@ -12,16 +12,16 @@ if (!demo) throw new Error(`No demo for id "${id}"`);
 
 <figure class="ba" data-demo={id} data-show="before">
   <div class="ba-head">
-    <div class="ba-switch" role="tablist" aria-label="Before / after">
+    <div class="ba-switch" role="group" aria-label="Before / after">
       <span class="ba-thumb no-anim" aria-hidden="true"></span>
-      <button type="button" role="tab" data-ba="before" aria-selected="true">
+      <button type="button" data-ba="before" aria-pressed="true">
         <span class="dot slop" aria-hidden="true"></span>
         <span class="ba-lbl">
           <span class="ba-lbl-live"><T zh="slop" en="Slop" ja="Slop" ko="Slop" /></span>
           <span class="ba-lbl-ghost" aria-hidden="true"><T zh="slop" en="Slop" ja="Slop" ko="Slop" /></span>
         </span>
       </button>
-      <button type="button" role="tab" data-ba="after" aria-selected="false">
+      <button type="button" data-ba="after" aria-pressed="false">
         <span class="dot clean" aria-hidden="true"></span>
         <span class="ba-lbl">
           <span class="ba-lbl-live"><T zh="清理后" en="Clean" ja="クリーン" ko="정리 후" /></span>
@@ -111,7 +111,7 @@ if (!demo) throw new Error(`No demo for id "${id}"`);
   .ba-switch button + button {
     border-left: var(--hair) solid var(--rule);
   }
-  .ba-switch button[aria-selected="true"] {
+  .ba-switch button[aria-pressed="true"] {
     color: var(--ink);
     font-weight: 600;
     background: color-mix(in oklab, var(--ink) 5%, transparent);
@@ -145,7 +145,7 @@ if (!demo) throw new Error(`No demo for id "${id}"`);
   }
   /* The inactive side recedes: its dot dims so only the selected segment reads
      as lit. */
-  .ba-switch button:not([aria-selected="true"]) .dot {
+  .ba-switch button:not([aria-pressed="true"]) .dot {
     opacity: 0.4;
   }
   .dot.slop {
@@ -504,7 +504,7 @@ if (!demo) throw new Error(`No demo for id "${id}"`);
     const thumb = ba.querySelector<HTMLElement>(".ba-thumb");
     function positionThumb() {
       const active = ba.querySelector<HTMLElement>(
-        '[data-ba][aria-selected="true"]',
+        '[data-ba][aria-pressed="true"]',
       );
       if (!thumb || !active) return;
       // offsetLeft/Width are relative to .ba-switch (the positioned ancestor),
@@ -530,7 +530,7 @@ if (!demo) throw new Error(`No demo for id "${id}"`);
         const wasClean = ba.dataset.show === "after";
         ba.dataset.show = mode;
         ba.querySelectorAll<HTMLButtonElement>("[data-ba]").forEach((b) =>
-          b.setAttribute("aria-selected", String(b.dataset.ba === mode)),
+          b.setAttribute("aria-pressed", String(b.dataset.ba === mode)),
         );
         positionThumb(); // glide the pill onto the newly selected tab
         // Sweep only when actually cleaning (slop → clean), never in reverse.

--- a/website/src/components/SlopEntry.astro
+++ b/website/src/components/SlopEntry.astro
@@ -222,7 +222,12 @@ const num = String(entry.n).padStart(2, "0");
       history.replaceState(null, "", "#" + id);
       document
         .getElementById(id)
-        ?.scrollIntoView({ behavior: "smooth", block: "start" });
+        ?.scrollIntoView({
+          behavior: window.matchMedia("(prefers-reduced-motion: reduce)").matches
+            ? "auto"
+            : "smooth",
+          block: "start",
+        });
       const url = location.origin + location.pathname + "#" + id;
       navigator.clipboard
         ?.writeText(url)

--- a/website/src/layouts/Base.astro
+++ b/website/src/layouts/Base.astro
@@ -138,7 +138,7 @@ const ogAlt =
   <body>
     <a class="skip" href="#main">Skip to content</a>
     <Nav />
-    <main id="main">
+    <main id="main" tabindex="-1">
       <slot />
     </main>
     <Footer />

--- a/website/src/styles/tokens.css
+++ b/website/src/styles/tokens.css
@@ -29,7 +29,7 @@
   --card: #fafcfe;         /* soft white — never clinical pure #fff */
   --ink: #1a1b1d;          /* rich near-black, faintly cool */
   --ink-2: #5e5f61;        /* secondary text */
-  --ink-3: #8e8f91;        /* meta, captions */
+  --ink-3: #6e7072;        /* meta, captions */
   --rule: #e1e3e5;         /* hairline rules & borders */
   --rule-strong: #c5c7c9;
 
@@ -132,7 +132,7 @@
     --card: #202127;
     --ink: #ecebe6;
     --ink-2: #a9a8a2;
-    --ink-3: #74736e;
+    --ink-3: #7f7d78;
     --rule: #2c2d33;
     --rule-strong: #3d3e45;
     --mark: #6faa8e;
@@ -147,7 +147,7 @@
   --card: #202127;
   --ink: #ecebe6;
   --ink-2: #a9a8a2;
-  --ink-3: #74736e;
+  --ink-3: #7f7d78;
   --rule: #2c2d33;
   --rule-strong: #3d3e45;
   --mark: #6faa8e;


### PR DESCRIPTION
## Summary

- validate scan roots, ignore the installed skill itself, support multiline and MDX signals, and neutralize terminal control sequences in human reports
- cover scanner contracts with four dependency-free regression cases
- correct the catalogue count and improve keyboard, motion, ARIA, and contrast accessibility

## Why

Misspelled roots previously produced a successful clean report; formatted source and MDX missed documented signals; project-local installations scanned their own files; and scanner output could contain terminal controls.

## Checks

Scanner regression suite: 4 passing. Astro production build: passing. Diff whitespace check: passing.